### PR TITLE
fix: dynamically create missing attribute objects in state_changed handler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -664,7 +664,7 @@ class HassAdapter extends Adapter {
 
         this.hass.on('error', err => this.log.error(err));
 
-        this.hass.on('state_changed', entity => {
+        this.hass.on('state_changed', async entity => {
             this.log.debug(`HASS-Message: State Changed: ${JSON.stringify(entity)}`);
             if (!entity || typeof entity.entity_id !== 'string') {
                 return;
@@ -711,6 +711,27 @@ class HassAdapter extends Adapter {
                     }
                     const attrId = attr.replace(this.FORBIDDEN_CHARS, '_').replace(/\.+$/, '_');
                     if (this.hassObjects[`${this.namespace}.${id}state`]) {
+                        const fullAttrId = `${this.namespace}.${id}${attrId}`;
+                        if (!this.hassObjects[fullAttrId]) {
+                            // Attribute appeared after initial sync — create object dynamically
+                            const common: ioBroker.StateCommon = {
+                                ...(knownAttributes[attr] as ioBroker.StateCommon | undefined),
+                                name: attr.replace(/_/g, ' '),
+                                read: true,
+                                write: false,
+                                role: 'state',
+                                type: (mapTypes[typeof entity.attributes[attr]] ?? 'mixed') as ioBroker.CommonType,
+                            };
+                            const newObj: ioBroker.StateObject = {
+                                _id: fullAttrId,
+                                type: 'state',
+                                common,
+                                native: { entity_id: entity.entity_id, attr },
+                            };
+                            this.log.debug(`Creating missing attribute object ${fullAttrId}`);
+                            await this.setForeignObjectAsync(fullAttrId, newObj);
+                            this.hassObjects[fullAttrId] = newObj;
+                        }
                         this.setState(id + attrId, { val, ack: true, lc, ts });
                     } else {
                         this.log.info(


### PR DESCRIPTION
## Problem

When Home Assistant reports a new attribute for an entity after the initial sync — e.g. `source_list` or `media_channel` appearing when a media player becomes active — `setState` is called without a corresponding ioBroker object existing. This causes repeated warnings:

```
State "hass.0.entities.media_player.wohnzimmer.media_channel" has no existing object, this might lead to an error in future versions
```

## Root cause

In the `state_changed` handler, the code checks whether `hassObjects[id + 'state']` exists (the entity's main state object) before writing attribute states. However it does **not** check whether the specific attribute object exists. If an attribute first appears after the initial sync, its object is never created and every subsequent update triggers the warning.

## Fix

Before calling `setState` for an attribute, check if `hassObjects[fullAttrId]` exists. If not, create the object dynamically via `setForeignObjectAsync` and register it in `hassObjects`. The callback is now `async` to support the await.

## Tested

Reproduced with a Sonos media player reporting `source_list` and `media_channel` attributes after startup. After this fix, the adapter creates the missing objects on first encounter and warnings are gone.